### PR TITLE
Fix crash on `About`

### DIFF
--- a/authenticator/src/main/java/me/henneke/wearauthn/ui/main/AuthenticatorMainMenu.kt
+++ b/authenticator/src/main/java/me/henneke/wearauthn/ui/main/AuthenticatorMainMenu.kt
@@ -31,6 +31,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
+import me.henneke.wearauthn.BuildConfig
 import me.henneke.wearauthn.LogLevel
 import me.henneke.wearauthn.Logging
 import me.henneke.wearauthn.R
@@ -123,6 +124,10 @@ class AuthenticatorMainMenu : PreferenceFragment(), CoroutineScope, Logging {
             findPreference(getString(R.string.preference_single_factor_mode_key)) as SwitchPreference
         manageCredentialsPreference =
             findPreference(getString(R.string.preference_credential_management_key))
+        with(findPreference(getString(R.string.preference_about_key))) {
+            intent = Intent(context, AboutActivity::class.java)
+            intent.`package` = BuildConfig.APPLICATION_ID
+        }
         supportPreference = findPreference(getString(R.string.preference_support_key))
     }
 

--- a/authenticator/src/main/res/xml/preferences_authenticator.xml
+++ b/authenticator/src/main/res/xml/preferences_authenticator.xml
@@ -65,13 +65,7 @@
             android:key="@string/preference_about_key"
             android:order="@integer/order_device_list_about"
             android:persistent="false"
-            android:title="@string/preference_about_title">
-            <!-- Inspection is unhappy about the package, but it's required for the intent to work -->
-            <!--suppress AndroidDomInspection -->
-            <intent
-                android:targetClass="me.henneke.wearauthn.ui.main.AboutActivity"
-                android:targetPackage="me.henneke.wearauthn.authenticator" />
-        </Preference>
+            android:title="@string/preference_about_title" />
 
         <Preference
             android:icon="@drawable/ic_launcher_outline"


### PR DESCRIPTION
The intent's `targetPackage` needs to be set dynamically as the application ID is different for nightly builds.